### PR TITLE
Trigger rebuild for v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # KTailctl
 
+
 Flathub repo for [KTailctl](https://github.com/f-koehler/KTailctl)


### PR DESCRIPTION
Somehow the x86 official build failed, see [https://buildbot.flathub.org/#/builders/7/builds/9195](https://buildbot.flathub.org/#/builders/7/builds/9195). This PR is supposed to trigger a rebuild.