### PR TITLE
chore: bump to 6.9 runtime

### DIFF
--- a/org.fkoehler.KTailctl.yml
+++ b/org.fkoehler.KTailctl.yml
@@ -1,6 +1,6 @@
 app-id: org.fkoehler.KTailctl
 runtime: org.kde.Platform
-runtime-version: "6.8"
+runtime-version: "6.9"
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
tested with `flatpak run --runtime-version=6.9 org.fkoehler.KTailctl`

needs https://github.com/f-koehler/KTailctl/pull/402